### PR TITLE
don't crash when hasCredential.type is a string

### DIFF
--- a/app/components/CertificateItem/index.tsx
+++ b/app/components/CertificateItem/index.tsx
@@ -55,7 +55,7 @@ export const CertificateItem: React.FC<CertificateItemProps> = ({
       <Text style={styles.credentialName}>{certificate.credentialSubject.hasCredential.name}</Text>
       <Text>
         <Text style={styles.fieldTitle}>Type: </Text>
-        <Text style={styles.fieldValue}>{certificate.credentialSubject.hasCredential.type.join(', ')}</Text>
+        <Text style={styles.fieldValue}>{Array.isArray(certificate.credentialSubject.hasCredential.type) ? certificate.credentialSubject.hasCredential.type.join(', '): certificate.credentialSubject.hasCredential.type}</Text>
       </Text>
 
       <Text>


### PR DESCRIPTION
untested fix for #105